### PR TITLE
Update docs deployment URL to connect.copilot-workshops.com

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,5 +66,5 @@ This is a crowdfunding platform for games with a developer theme. The applicatio
   - `src/styles/`: CSS and Tailwind configuration
 - `scripts/`: Development and deployment scripts
 - `data/`: Database files
-- `docs/`: Project documentation
+- `docs/`: Project documentation - Automatically deployed to GitHub Pages: https://connect.copilot-workshops.com
 - `README.md`: Project documentation

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then navigate to the [website](http://localhost:4321) to see the site!
 ## Documentation
 
 The complete workshop documentation is automatically published at GitHub Pages and available at:
-**https://se-copilot-workshops.github.io/agents-in-sdlc/**
+**https://connect.copilot-workshops.com**
 
 The documentation is automatically deployed from the `docs/` directory when changes are pushed to main.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Agents in the software development lifecycle (SDLC)
 
-> **Live Documentation:** This workshop documentation is published at [https://se-copilot-workshops.github.io/agents-in-sdlc/](https://se-copilot-workshops.github.io/agents-in-sdlc/)
+> **Live Documentation:** This workshop documentation is published at [https://connect.copilot-workshops.com](https://connect.copilot-workshops.com)
 
 The recent additions to the capabilities of GitHub Copilot provide powerful tools to the developer across the entire software development lifecycle (SDLC). This includes working with issues and pull requests on GitHub, interacting with external services, and of course code creation. This lab explores the functionality, providing real-world use cases and tips on how to get the most out of the tools.
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,7 @@
 title: Agents in the SDLC
 description: Learn how to leverage GitHub Copilot agents across the software development lifecycle
+baseurl: ""
+url: "https://connect.copilot-workshops.com"
 repository: se-copilot-workshops/agents-in-sdlc
 remote_theme: just-the-docs/just-the-docs
 plugins:


### PR DESCRIPTION
## Summary

Update the documentation site configuration and all references to deploy at the custom domain `https://connect.copilot-workshops.com` instead of `https://se-copilot-workshops.github.io/agents-in-sdlc/`.

## Changes

- **`docs/_config.yml`** — Added `baseurl: ""` and `url` for the custom domain
- **`README.md`** — Updated documentation URL
- **`docs/README.md`** — Updated live documentation link
- **`.github/copilot-instructions.md`** — Added deployment URL to `docs/` entry

No workflow changes needed — `actions/configure-pages@v5` handles custom domain configuration automatically.